### PR TITLE
Fix --build of the postgres sql so it loads a volume

### DIFF
--- a/postgres-db/docker-compose.yml
+++ b/postgres-db/docker-compose.yml
@@ -21,7 +21,7 @@ services:
           - "5432:5432"
 
     volumes:
-       - ./postgresql_data:/var/lib/postgresql/data
+       - ./postgresql_data:/var/lib/postgresql
 
     restart: unless-stopped
 volumes:

--- a/postgres-db/seed.sql
+++ b/postgres-db/seed.sql
@@ -3,4 +3,4 @@ id SERIAL PRIMARY KEY,
 name VARCHAR(500) NOT NULL,
 completed BOOLEAN NOT NULL);
 
-COPY ${PG_TABLE} FROM '/var/lib/postgresql/data/init.table.csv' DELIMITER ',' CSV HEADER;
+COPY ${PG_TABLE} FROM '/var/lib/postgresql/init.table.csv' DELIMITER ',' CSV HEADER;


### PR DESCRIPTION
When first loading the app, a volume of the table is not created. Amend the variable of 'data' so that a volume gets created for build. Now you can connect to it via node-app